### PR TITLE
110: Render open answer box without displaying previous answers ( comments tree ) 

### DIFF
--- a/app/views/comments/_open_answer_box.html.erb
+++ b/app/views/comments/_open_answer_box.html.erb
@@ -1,0 +1,39 @@
+<% valuation = local_assigns.fetch(:valuation, false) %>
+<% allow_comments = local_assigns.fetch(:allow_comments, true) %>
+<% cache [locale_and_user_status, commentable_cache_key(commentable), commentable.comments_count] do %>
+  <section class="expanded comments">
+    <div class="row">
+      <div id="comments" class="small-12 column">
+        <h2>
+          <%= comment_tree_title_text(commentable) %>
+        </h2> 
+        
+        <% if user_signed_in? %>
+          <% if comments_closed_for_commentable?(commentable) %>
+            <br>
+            <div data-alert class="callout primary">
+              <%= comments_closed_text(commentable) %>
+            </div>
+          <% elsif require_verified_resident_for_commentable?(commentable, current_user) %>
+            <br>
+            <div data-alert class="callout primary">
+              <%= t("comments.verified_only", verify_account: link_to(t("comments.verify_account"), verification_path )).html_safe %>
+            </div>
+          <% elsif allow_comments %>
+            <%= render "comments/form", { commentable: commentable,
+                                          parent_id: nil,
+                                          toggeable: false,
+                                          valuation: valuation } %>
+          <% end %>
+        <% else %>
+          <br>
+          <div data-alert class="callout primary">
+            <%= t("debates.show.login_to_comment",
+                signin: link_to(t("votes.signin"), new_user_session_path),
+                signup: link_to(t("votes.signup"), new_user_registration_path)).html_safe %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </section>
+<% end %>

--- a/app/views/legislation/questions/show.html.erb
+++ b/app/views/legislation/questions/show.html.erb
@@ -41,8 +41,5 @@
       <%= render "/shared/social_share", title: @question.title, url: legislation_process_question_url(@question.process, @question) %>
     </aside>
   </div>
-
-  <%= render partial: "/comments/comment_tree", locals: { comment_tree: @comment_tree,
-                                                          comment_flags: @comment_flags,
-                                                          display_comments_count: true } %>
+  <%= render partial: "/comments/open_answer_box", locals: { commentable: @question } %>
 </section>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,5 +1,5 @@
 default: &default
-  version: "0.19.6"
+  version: "0.19.7"
   server_name: <%= ENV['CONSUL_SERVER_NAME'] || "localhost:3000" %>
   twitter_key: <%= ENV['TWITTER_KEY'] || "" %>
   twitter_secret: <%= ENV['TWITTER_SECRET'] || "" %>

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,5 +1,5 @@
 default: &default
-  version: "0.19.6"
+  version: "0.19.7"
   secret_key_base: 56792feef405a59b18ea7db57b4777e855103882b926413d4afdfb8c0ea8aa86ea6649da4e729c5f5ae324c0ab9338f789174cf48c544173bc18fdc3b14262e4
   email_interceptor_recipients: ""
 


### PR DESCRIPTION
## Visual Changes
Comments tree removed
![image](https://user-images.githubusercontent.com/11981811/59964982-164f9980-94ce-11e9-968b-78c41f966846.png)
