### PR TITLE
remove resident_document_type field

### DIFF
--- a/app/views/verification/residence/new.html.erb
+++ b/app/views/verification/residence/new.html.erb
@@ -36,33 +36,6 @@
     <%= form_for @residence, as: "residence", url: residence_path do |f| %>
       <%= render "errors" %>
 
-      <div class="row">
-        <div class="small-12 medium-8">
-          <div class="small-12 medium-3 column">
-          <%= f.label t("verification.residence.new.document_type_label") %>
-          <%= f.select :document_type, document_types, prompt: "", label: false %>
-          </div>
-          <div class="small-12 medium-5 column end">
-
-          <div class="inline-block">
-            <%= f.label t("verification.residence.new.document_number") %>
-          </div>
-
-          <div class="inline-block" data-toggle="info-document-number">
-            <span class="icon-help"></span>
-            <span class="show-for-sr"><%= t("verification.residence.new.document_number_help_title") %></span>
-          </div>
-
-          <div class="dropdown-pane" id="info-document-number" data-dropdown
-               data-hover="true" data-hover-pane="true">
-            <%= t("verification.residence.new.document_number_help_text_html") %>
-          </div>
-
-          <%= f.text_field :document_number, label: false %>
-          </div>
-        </div>
-      </div>
-
       <div class="date-of-birth small-12 medium-6 clear">
       <%= f.label t("verification.residence.new.date_of_birth") %>
       <%= f.date_select :date_of_birth,


### PR DESCRIPTION
Because document field is not mandatory and not avg proof

## References

> https://gitlab.com/participation.tools/consul/issues/246

## Objectives

> Remove unused field

## Visual Changes

<img width="828" alt="Screenshot 2019-10-01 at 13 36 21" src="https://user-images.githubusercontent.com/47716558/65963496-2676fd80-e45b-11e9-8714-c29efc86b1e6.png">

## Notes

Needs to be tested in test instance
