### PR TITLE
algemene fout in vertaling

### DIFF
--- a/config/locales/nl/general.yml
+++ b/config/locales/nl/general.yml
@@ -628,7 +628,7 @@ nl:
         found:
           one: Er is een voorstel met de term '%{query}', u kunt hierin deelnemen, in plaats van het openen van een nieuwe voorstel.
           other: Er is een voorstel met de term '%{query}', u kunt hierin deelnemen, in plaats van het openen van een nieuwe voorstel.
-        message: "%{limit} van %{count} beleggingen met de term '%{query}'"
+        message: "%{limit} van %{count} voorstellen met de term '%{query}'"
         see_all: Bekijk alles
       debate:
         found:


### PR DESCRIPTION
**beleggingen** moet worden veranderd in **voorstellen**

`631        message: "%{limit} van %{count} beleggingen met de term '%{query}'"`

`631        message: "%{limit} van %{count} voorstellen met de term '%{query}'"`

