### PR TITLE
fix link leading to same page

### DIFF
--- a/app/views/budgets/ballot/_ballot.html.erb
+++ b/app/views/budgets/ballot/_ballot.html.erb
@@ -1,6 +1,6 @@
 <div class="expanded budget no-margin-top padding">
   <div class="row">
-    <%= back_link_to @ballot_referer %>
+    <%= back_link_to budget_investments_path(investment.budget, heading_id: investment.heading) %>
 
     <h1 class="text-center"><%= t("budgets.ballots.show.title") %></h1>
 


### PR DESCRIPTION
back_link_to budget_investments_path(investment.budget, heading_id: investment.heading)

instead of

back_link_to @ballot_referer

Should be first deployed on tested on groningen.consulproject.nl

## References

> Related Issues/Pull Requests/Travis Builds/Rollbar errors/etc...

## Objectives

> What are the objectives of these changes?

## Visual Changes

> Any visual changes? please attach screenshots (or gifs) showing them.
> If modified views are public (not the admin panel), try them in mobile display (with your browser's developer console) and add screenshots.

## Notes

> Mention rake tasks or actions to be done when deploying this changes to a server (if any).
> Explain any caveats, or important things to notice like deprecations (if any).
